### PR TITLE
Add headings documentation

### DIFF
--- a/src/elements/heading.jsx
+++ b/src/elements/heading.jsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { classNames } from 'utils'
+
+/**
+ * Heading component is a simple wrapper around standard HTML headings.
+ */
+const Heading = ({
+  children,
+  className,
+  level,
+  display,
+  tag: Tag = `h${level}`,
+  ...restProps
+}) => (
+  <Tag className={classNames.use({ display }, className)} {...restProps}>
+    {children}
+  </Tag>
+)
+
+Heading.propTypes = {
+  /**
+   * An integer between 1 and 6 (including) to calculate the tag.
+   * NOTE: If `tag` prop is passed, `level` will be ignored.
+   */
+  level: PropTypes.number.isRequired,
+  /**
+   * A toggle for display mode.
+   */
+  display: PropTypes.bool,
+}
+
+Heading.defaultProps = {
+  display: false,
+}
+
+export default Heading

--- a/src/elements/heading.md
+++ b/src/elements/heading.md
@@ -1,0 +1,11 @@
+#### Application heading
+
+```jsx
+<Heading level="1">Heading 1</Heading>
+```
+
+#### Display heading
+
+```jsx
+<Heading level="1" display>Display heading 1</Heading>
+```

--- a/src/elements/index.js
+++ b/src/elements/index.js
@@ -1,0 +1,1 @@
+export Heading from './heading'

--- a/src/foundation/README.md
+++ b/src/foundation/README.md
@@ -1,0 +1,44 @@
+## Headings
+
+### Application headings
+
+This set of headings are useful when you need it for applications,
+where content is dense and you basically need small headings.
+
+```jsx
+<h1>Heading 1</h1>
+<h2>Heading 2</h2>
+<h3>Heading 3</h3>
+<h4>Heading 4</h4>
+<h5>Heading 5</h5>
+<h6>Heading 6</h6>
+```
+
+### Display headings
+
+For pages where headings should take attention, e.g. landing pages, you can
+easily turn headings to display mode using `display` class.
+
+```jsx
+<h1 class="display">Display Heading 1</h1>
+<h2 class="display">Display Heading 2</h2>
+<h3 class="display">Display Heading 3</h3>
+<h4 class="display">Display Heading 4</h4>
+<h5 class="display">Display Heading 5</h5>
+<h6 class="display">Display Heading 6</h6>
+```
+
+However, if you are not going to mix heading sizes, you can turn **all**
+headings to display mode in more easy way just adding `display` class
+to a parent element.
+
+```jsx
+<div className="display">
+  <h1>Heading 1</h1>
+  <h2>Heading 2</h2>
+  <h3>Heading 3</h3>
+  <h4>Heading 4</h4>
+  <h5>Heading 5</h5>
+  <h6>Heading 6</h6>
+</div>
+```

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
+export * from './elements'
 export Icon from './components/icon'

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -9,6 +9,14 @@ module.exports = {
       content: './docs/intro.md',
     },
     {
+      name: 'Foundation',
+      content: 'src/foundation/README.md',
+    },
+    {
+      name: 'Elements',
+      components: 'src/elements/**/*.{js,jsx,ts,tsx}',
+    },
+    {
       name: 'Components',
       sections: [
         {
@@ -24,6 +32,14 @@ module.exports = {
       linkHover: '#924300',
     },
   },
+
+  ignore: [
+    '**/__tests__/**',
+    '**/*.test.{js,jsx,ts,tsx}',
+    '**/*.spec.{js,jsx,ts,tsx}',
+    '**/*.d.ts',
+    '**/index.{js,jsx,ts,tsx}',
+  ],
 
   styleguideDir: 'public',
 


### PR DESCRIPTION
Adds `Heading` component and a simple documentation about how CSS custom properties work with the typography.