### PR TITLE
Fix font face based on custom property

### DIFF
--- a/src/foundation/type.css
+++ b/src/foundation/type.css
@@ -1,5 +1,8 @@
 :root {
   --headings-color: var(--gray-900);
+  --font-family-base: roboto, -apple-system, blinkmacsystemfont, 'Segoe UI',
+    'Helvetica Neue', arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   --code-color: inherit;
   --kbd-color: var(--gray-900);
   --kbd-bg: var(--gray-50);
@@ -7,9 +10,6 @@
 
 body {
   margin: 0;
-  font-family: roboto, -apple-system, blinkmacsystemfont, 'Segoe UI',
-    'Helvetica Neue', arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   font-family: var(--font-family-base);
   font-size: var(--font-size-base, 1rem);
   font-weight: var(--font-weight-base, 400);

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -33,28 +33,6 @@ module.exports = {
     },
   },
 
-  styles: {
-    StyleGuide: {
-      '@global body': {
-        fontFamily: [
-          'Roboto',
-          '-apple-system',
-          'BlinkMacSystemFont',
-          'Segoe UI',
-          'Helvetica Neue',
-          'Arial',
-          'Noto Sans',
-          'sans-serif',
-          'Apple Color Emoji',
-          'Segoe UI Emoji',
-          'Segoe UI Symbol',
-          'Noto Color Emoji',
-        ].join(', '),
-        lineHeight: 1.5,
-      },
-    },
-  },
-
   ignore: [
     '**/__tests__/**',
     '**/*.test.{js,jsx,ts,tsx}',


### PR DESCRIPTION
Adds `--font-family-base` to fix missing font face.

Removes redundant font-family duplication from styleguidist
configuration.