### PR TITLE
Fix generate unique ID for every text field

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -9,3 +9,5 @@ settings:
     node:
       paths: ['./src']
       extensions: ['.js', '.jsx']
+rules:
+  react/require-default-props: off

--- a/src/elements/forms/text-field.jsx
+++ b/src/elements/forms/text-field.jsx
@@ -24,10 +24,10 @@ const generateId = () =>
 
 const TextField = ({
   children,
-  id,
+  id = generateId(),
   className,
   label,
-  size,
+  size = 'default',
   tag: Tag = 'div',
   ...inputProps
 }) => {
@@ -63,11 +63,6 @@ TextField.propTypes = {
    * If not passed, it will be generated automatically using a random string.
    */
   id: PropTypes.string,
-}
-
-TextField.defaultProps = {
-  size: 'default',
-  id: generateId(),
 }
 
 export default TextField


### PR DESCRIPTION
If we use default props. All text fields will share the same ID. This PR should prevent it.