### PR TITLE
Use published event for package release

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -2,7 +2,7 @@ name: oacore/design publish
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   publish-gpr:


### PR DESCRIPTION
Created event is not triggered when release draft is converted to published