### PR TITLE
Improve TextField API and styles

### DIFF
--- a/src/elements/forms/text-field.css
+++ b/src/elements/forms/text-field.css
@@ -2,8 +2,10 @@
   /* Control */
   --form-control-corner-radius: var(--component-corner-radius, 2px);
   --form-control-border-width: 1px;
+  --form-control-font-size: var(--body-font-size, 1rem);
   --form-control-padding-x: var(--component-padding, 1rem);
   --form-control-padding-y: var(--component-padding, 1rem);
+  --form-control-background-color: var(--white);
   --form-control-color: var(--primary);
 
   /* Label */
@@ -13,18 +15,63 @@
   --form-label-font-size: 0.75em;
 
   /* Helper */
-  --form-helper-font-size: var(--font-size-small, 0.875em);
+  --form-helper-font-size: var(--body-font-size-small, 0.875em);
   --form-helper-color: var(--gray-600);
 }
 
-/* Global styles */
+%label {
+  display: block;
+  font-size: var(--form-label-font-size);
+  line-height: 1;
+  color: var(--form-label-color);
+  border-radius: var(--form-control-corner-radius, 2px);
+  transition: 150ms;
+  transform-origin: left;
+}
 
-/* TODO: Move to Foundation partially */
-input {
+%label-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: var(--form-label-padding-y) var(--form-label-padding-x);
+  margin: calc(var(--form-control-padding-y) - var(--form-label-padding-y))
+    calc(var(--form-control-padding-x) - var(--form-label-padding-x));
+  font-size: var(--form-control-font-size);
+}
+
+%label-overlay-focus {
+  font-size: var(--form-label-font-size);
+  background-color: var(--form-control-background-color);
+
+  /**
+   * A line on top of the input border
+   *
+   * If keep the background-color transparent this will only cover the border
+   * of the input and the text will be like on top of everything.
+   *
+   * However, such effect may lead
+   */
+  background-image: linear-gradient(
+    transparent calc(50% - calc(var(--form-control-border-width) / 2)),
+    var(--form-control-background-color)
+      calc(50% - calc(var(--form-control-border-width) / 2)),
+    var(--form-control-background-color)
+      calc(50% + calc(var(--form-control-border-width) / 2)),
+    transparent calc(50% + calc(var(--form-control-border-width) / 2))
+  );
+  transform: translateY(calc(-0.5em - var(--form-control-padding-y)));
+}
+
+%control {
   display: block;
   width: 100%;
-  height: calc(2 * var(--form-control-padding-y) + 1em);
-  padding: var(--form-control-padding-y) var(--form-control-padding-x);
+  height: calc(2 * var(--form-control-padding-y) + 1rem);
+  padding: calc(
+      var(--form-control-padding-y) - var(--form-control-border-width)
+    )
+    calc(var(--form-control-padding-x) - var(--form-control-border-width));
+  font-size: var(--form-control-font-size);
+  background-color: var(--form-control-background-color);
   border: var(--form-control-border-width) solid var(--form-control-color);
   border-radius: var(--form-control-corner-radius);
 
@@ -34,33 +81,49 @@ input {
   }
 }
 
-::placeholder {
-  color: var(--gray-600);
-  opacity: 0;
+%placeholder {
   transition: 150ms;
+}
+
+%placeholder-hidden {
+  opacity: 0;
   transform: translateY(calc(1em + var(--form-control-padding-y)));
 }
 
-label {
-  position: absolute;
-  top: 0;
-  display: block;
-  padding: var(--form-label-padding-y) var(--form-label-padding-x);
-  margin: calc(var(--form-control-padding-y) - var(--form-label-padding-y))
-    calc(var(--form-control-padding-x) - var(--form-label-padding-x));
-  line-height: 1;
-  color: var(--form-label-color);
-  border-radius: var(--form-control-corner-radius, 2px);
-  transition: 150ms;
-  transform-origin: left;
+%placeholder-shown {
+  opacity: 0.6;
+  transform: translateY(0);
 }
 
-/* Text field */
 .container {
   position: relative;
 }
 
-/* Helper message */
+.control {
+  @extend %control;
+}
+
+.control::placeholder {
+  @extend %placeholder;
+  @extend %placeholder-hidden;
+}
+
+.control:focus::placeholder {
+  @extend %placeholder-shown;
+}
+
+.label {
+  @extend %label;
+}
+
+.control ~ .label {
+  @extend %label-overlay;
+}
+
+.control:matches(:focus, :not(:placeholder-shown)) ~ .label {
+  @extend %label-overlay-focus;
+}
+
 .helper {
   display: block;
   padding-right: var(--form-control-padding-x);
@@ -74,49 +137,47 @@ label {
   }
 }
 
-input:disabled,
-input:read-only,
-input:disabled + label,
-input:read-only + label {
-  --form-control-color: var(--gray-500);
-  --form-label-color: var(--gray-500);
-}
-
-input:disabled {
-  cursor: not-allowed;
-}
-
 /* Size variations */
 .small {
   --form-control-padding-y: calc(0.75 * var(--component-padding, 1rem));
+  --form-control-font-size: var(--body-font-size-small);
 }
 
 .large {
   --form-control-padding-y: calc(1.25 * var(--component-padding, 1rem));
 }
 
-/* Behaviour variations */
-:matches(input, select, textarea):focus + label,
-:matches(input, select, textarea):not(:placeholder-shown) + label,
-:matches(input, select, textarea):-webkit-autofill + label,
-.focus label {
-  font-size: var(--form-label-font-size);
-  background: var(--white, #fff);
-  transform: translateY(
-    calc(
-      -1 * var(--form-control-padding-y) - var(--form-label-font-size) / 2 - var(--form-control-border-width)
-    )
-  );
+/* Colour and shape variations */
+.pure {
+  /* Kepping screenreader-only tweak as is (with !important-s) for a safety */
+  /* stylelint-disable declaration-no-important */
+  & > .label {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
+  }
+  /* stylelint-enable declaration-no-important */
 }
 
-.focus::placeholder,
-:focus::placeholder {
-  opacity: 1;
-  transform: none;
+.focus {
+  & > .label {
+    @extend %label-overlay-focus;
+  }
+
+  & > .control::placeholder {
+    @extend %placeholder-shown;
+  }
 }
 
-/* Colour variations */
 .success {
+  @extend .focus;
+
   --form-control-color: var(--success-dark);
   --form-helper-color: var(--form-control-color);
 
@@ -125,6 +186,8 @@ input:disabled {
 }
 
 .error {
+  @extend .focus;
+
   --form-control-color: var(--danger-dark);
   --form-helper-color: var(--form-control-color);
 
@@ -133,7 +196,63 @@ input:disabled {
 }
 
 .touched:invalid,
-.touched:invalid + label {
+.touched:invalid ~ label {
   --form-control-color: var(--danger-dark);
   --form-label-color: var(--form-control-color);
+}
+
+/* Globals */
+label {
+  @extend %label;
+}
+
+::placeholder {
+  @extend %placeholder;
+}
+
+input:not([type]),
+[type='text'],
+[type='search'],
+[type='password'],
+[type='email'],
+[type='number'],
+[type='tel'],
+[type='url'],
+[type='date'],
+[type='datetime-local'],
+[type='time'],
+[type='week'],
+[type='month'],
+select,
+textarea {
+  @extend %control;
+
+  & ~ label {
+    @extend %label;
+    @extend %label-overlay;
+  }
+
+  &:matches(:focus) ~ label {
+    @extend %label-overlay-focus;
+  }
+
+  &::placeholder {
+    @extend %placeholder-hidden;
+  }
+
+  &:focus::placeholder {
+    @extend %placeholder-shown;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+  }
+
+  &:disabled,
+  &:read-only,
+  &:disabled ~ label,
+  &:read-only ~ label {
+    --form-control-color: var(--gray-500);
+    --form-label-color: var(--gray-500);
+  }
 }

--- a/src/elements/forms/text-field.css
+++ b/src/elements/forms/text-field.css
@@ -49,7 +49,9 @@
    * If keep the background-color transparent this will only cover the border
    * of the input and the text will be like on top of everything.
    *
-   * However, such effect may lead
+   * However, such effect may be unwanted and leads to poor design on the
+   * non-white, especially image backgrounds. That is why we keep
+   * background-color at the moment.
    */
   background-image: linear-gradient(
     transparent calc(50% - calc(var(--form-control-border-width) / 2)),
@@ -82,7 +84,7 @@
 }
 
 %placeholder {
-  transition: 150ms;
+  transition: transform 150ms, opacity 150ms;
 }
 
 %placeholder-hidden {
@@ -124,6 +126,18 @@
   @extend %label-overlay-focus;
 }
 
+/**
+ * This code is duplicated because @extend rule breaks the behaviour in Firefox.
+ * The browser does not take into account comma-separated selectors where
+ * is a `-webkit-` prefix.
+ */
+
+.control:-webkit-autofill ~ label {
+  font-size: var(--form-label-font-size);
+  background-color: var(--form-control-background-color);
+  transform: translateY(calc(-0.5em - var(--form-control-padding-y)));
+}
+
 .helper {
   display: block;
   padding-right: var(--form-control-padding-x);
@@ -163,6 +177,9 @@
     border: 0 !important;
   }
   /* stylelint-enable declaration-no-important */
+  & > .control::placeholder {
+    @extend %placeholder-shown;
+  }
 }
 
 .focus {

--- a/src/elements/forms/text-field.jsx
+++ b/src/elements/forms/text-field.jsx
@@ -31,6 +31,7 @@ const TextField = React.forwardRef(
       size = 'default',
       labelSrOnly = false,
       tag: Tag = 'div',
+      placeholder = variant === 'pure' ? label : undefined,
       ...inputProps
     },
     ref
@@ -42,9 +43,9 @@ const TextField = React.forwardRef(
         id={id}
         className={classNames
           .use('container', {
+            // 'focus' should be applied directly to the control
+            [variant]: !['normal'].includes(variant),
             [size]: size !== 'default',
-            [variant]: variant !== 'normal',
-            focus: variant !== 'normal',
             touched: isTouched,
           })
           .from(styles)
@@ -56,22 +57,22 @@ const TextField = React.forwardRef(
           onBlur={() => !isTouched && setIsTouched(true)}
           aria-invalid={variant === 'error' ? 'true' : 'false'}
           aria-describedby={`${id}-helper`}
+          placeholder={placeholder}
           className={classNames
-            .use({
-              touched: isTouched,
-            })
+            .use('control', isTouched && 'touched')
             .from(styles)}
           {...inputProps}
         />
-        <label
-          htmlFor={controlId}
-          className={classNames.use(labelSrOnly && 'sr-only')}
-        >
-          {label}
-        </label>
+        {children}
         <span id={`${id}-helper`} className={styles.helper}>
           {helper}
         </span>
+        <label
+          htmlFor={controlId}
+          className={classNames.use(styles.label, labelSrOnly && 'sr-only')}
+        >
+          {label}
+        </label>
       </Tag>
     )
   }
@@ -83,7 +84,13 @@ TextField.propTypes = {
    */
   label: PropTypes.node.isRequired,
   /**
-   * Hide label and expose it only for screen readers
+   * Input's placeholder
+   */
+  placeholder: PropTypes.string,
+  /**
+   * Hide label and expose it only for screen readers.
+   *
+   * **Deprecated**. Use `variant="pure"` instead.
    */
   labelSrOnly: PropTypes.bool,
   /**
@@ -102,9 +109,12 @@ TextField.propTypes = {
    */
   helper: PropTypes.string,
   /**
-   * Helper variation. Affects coloUr of inputs
+   * Helper variation. Affects label position and the colour.
+   *
+   * Avoid using `pure`` with no `placeholder`, prefer to explicitly set it.
+   * However, if you don't, the `placeholder`` repeats the label text.
    */
-  variant: PropTypes.oneOf(['normal', 'focus', 'success', 'error']),
+  variant: PropTypes.oneOf(['normal', 'pure', 'focus', 'success', 'error']),
 }
 
 export default TextField

--- a/src/elements/forms/text-field.md
+++ b/src/elements/forms/text-field.md
@@ -1,5 +1,18 @@
 ### Type variations
 
+#### Text
+
+```jsx
+<TextField
+  id="text-example"
+  name="name"
+  label="Full name"
+  placeholder="e.g. John Doe"
+/>
+```
+
+
+
 Example with a search input:
 
 ```jsx
@@ -26,70 +39,6 @@ Example with a password:
 />
 ```
 
-Example `focus` variant (label on top):
-
-```jsx
-<TextField
-  id="focus-name"
-  name="name"
-  label="Name"
-  placeholder="e.g. John Doe"
-  variant="focus"
-/>
-```
-
-Example with error message:
-
-```jsx
-<TextField
-  id="error-name"
-  name="user-name"
-  label="User name"
-  placeholder="e.g. john"
-  helper="User name is required"
-  variant="error"
-/>
-```
-
-Example with success message:
-
-```jsx
-<TextField
-  id="success-name"
-  name="user-name"
-  label="User name"
-  value="john"
-  helper="Nice to meet you john!"
-  variant="success"
-/>
-```
-
-Example with disabled input:
-
-```jsx
-<TextField
-  id="disabled-input"
-  name="disabled-input"
-  label="Disabled input"
-  value="Disabled input"
-  variant="success"
-  disabled
-/>
-```
-
-Example with hidden label:
-
-```jsx
-<TextField
-  id="hidden-label"
-  name="hidden-label"
-  label="Input with hidden label"
-  labelSrOnly
-  value="Hidden label"
-  variant="success"
-/>
-```
-
 ### Size variations
 
 #### Small
@@ -109,5 +58,79 @@ Example with hidden label:
   label="Name"
   placeholder="e.g. John Doe"
   size="large"
+/>
+```
+
+### Label and colour variations
+
+#### Pure
+
+A TextField without a visible label. The label remains accessible to
+screen-readers.
+
+```jsx
+<TextField
+  variant="pure"
+  id="example-pure"
+  name="name"
+  placeholder="e.g. John Doe"
+  autocomplete="name"
+/>
+```
+
+#### Focus
+
+Example `focus` variant (label on top):
+
+```jsx
+<TextField
+  variant="focus"
+  id="example-focus"
+  name="name"
+  label="Name"
+  placeholder="e.g. John Doe"
+/>
+```
+
+#### Error
+
+Example with error message:
+
+```jsx
+<TextField
+  variant="error"
+  id="example-error"
+  name="user-name"
+  label="User name"
+  placeholder="e.g. john"
+  helper="User name is required"
+/>
+```
+
+#### Success
+
+Example with success message:
+
+```jsx
+<TextField
+  id="example-success"
+  name="user-name"
+  label="User name"
+  value="john"
+  helper="Nice to meet you john!"
+  variant="success"
+/>
+```
+
+Example with disabled input:
+
+```jsx
+<TextField
+  id="disabled-input"
+  name="disabled-input"
+  label="Disabled input"
+  value="Disabled input"
+  variant="success"
+  disabled
 />
 ```


### PR DESCRIPTION
Introduces class-first approach for the inputs.

Fixes the bug with the Firefox broken label animation by removing the `-webkit-autofill` selector.

---

@Joozty I wanted to fix the bug and ended up rewriting everything. Even if it seems not worth it, it is for me. This may be the first step of writing the next forms API in the library. Let me know what do you think about.