### PR TITLE
Allow to use own design config in the repo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5896,10 +5896,9 @@
       "dev": true
     },
     "deepmerge": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.3.2.tgz",
-      "integrity": "sha1-FmNpFinU2/42T6EqKk8KqGqjoFA=",
-      "dev": true
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "default-gateway": {
       "version": "4.2.0",
@@ -16852,6 +16851,14 @@
         "deepmerge": "1.3.2",
         "mitt": "1.1.2",
         "svg-baker": "^1.7.0"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.3.2.tgz",
+          "integrity": "sha1-FmNpFinU2/42T6EqKk8KqGqjoFA=",
+          "dev": true
+        }
       }
     },
     "svg-sprite-loader": {
@@ -16869,6 +16876,14 @@
         "svg-baker": "^1.5.0",
         "svg-baker-runtime": "^1.4.7",
         "url-slug": "2.0.0"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.3.2.tgz",
+          "integrity": "sha1-FmNpFinU2/42T6EqKk8KqGqjoFA=",
+          "dev": true
+        }
       }
     },
     "svg-tags": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@mdi/svg": "^5.3.45",
     "classnames": "^2.2.6",
     "cosmiconfig": "^6.0.0",
+    "deepmerge": "^4.2.2",
     "prop-types": "^15.7.2",
     "sanitize.css": "^11.0.1",
     "svgo": "^1.3.2",
@@ -83,8 +84,8 @@
     "build:css:global": "postcss 'src/**/*.css' --base src --env=global --dir lib/global --verbose",
     "build:lib": "run-p build:js build:css",
     "build:docs": "styleguidist build",
-    "build": "run-s build:lib build:docs",
-    "dev:docs": "styleguidist server",
+    "build": "NODE_ENV=production && run-s build:lib build:docs",
+    "dev:docs": "node bin build && styleguidist server",
     "dev:css": "npm run build:css -- --watch",
     "dev:js": "npm run build:js -- --watch",
     "dev": "run-p dev:*"

--- a/src/config.js
+++ b/src/config.js
@@ -3,8 +3,8 @@
  * via 'build-config' binary command from dependent project's local .designrc
  */
 
-const publicPath = '/assets'
-const iconsPublicPath = `${publicPath}/icons.svg`
+const publicPath = '/'
+const iconsPublicPath = `${publicPath}icons.svg`
 const config = { publicPath, iconsPublicPath }
 
 export default config

--- a/src/elements/icon/icon.md
+++ b/src/elements/icon/icon.md
@@ -7,7 +7,7 @@ so screen readers will be able to read it.
 
 ```jsx
 <button type="button">
-  <Icon src="check.svg" alt="OK" />
+  <Icon src="#check" alt="OK" />
 </button>
 ```
 
@@ -18,7 +18,12 @@ example.
 
 ```jsx
 <button type="button">
-  <Icon src="check.svg" alt="Check icon" aria-hidden />
+  <Icon src="#check" aria-hidden />
   OK
 </button>
+```
+
+## Test icon in sprite
+```jsx
+<Icon src="#ab-testing" aria-hidden />
 ```


### PR DESCRIPTION
This PR adds support for default config so we can use custom icons here too.

The flow is the following:
1. Load config from this repo and resolve icons with absolute path
2. Search for config in the project root `(/<project_root>/node_modules/@oacore/design/bin)`
3. Resolve icons in this config
4. Merge configs together

