### PR TITLE
Move forwardRef closer to Component

### DIFF
--- a/src/elements/forms/addon.jsx
+++ b/src/elements/forms/addon.jsx
@@ -5,17 +5,16 @@ import styles from './styles.css'
 
 import { classNames } from 'utils'
 
-const Addon = (
-  { place, className, children, tag: Tag = 'span', ...restProps },
-  ref
-) => (
-  <Tag
-    ref={ref}
-    className={classNames.use(styles.addon, styles[place]).join(className)}
-    {...restProps}
-  >
-    {children}
-  </Tag>
+const Addon = forwardRef(
+  ({ place, className, children, tag: Tag = 'span', ...restProps }, ref) => (
+    <Tag
+      ref={ref}
+      className={classNames.use(styles.addon, styles[place]).join(className)}
+      {...restProps}
+    >
+      {children}
+    </Tag>
+  )
 )
 
 Addon.propTypes = {
@@ -26,4 +25,4 @@ Addon.defaultProps = {
   place: 'append',
 }
 
-export default forwardRef(Addon)
+export default Addon

--- a/src/elements/forms/control.jsx
+++ b/src/elements/forms/control.jsx
@@ -4,27 +4,26 @@ import styles from './styles.css'
 
 import { classNames } from 'utils'
 
-const FormControl = (
-  { type: controlType, children, className, focus, ...htmlProps },
-  ref
-) => {
-  const Tag = ['select', 'textarea'].includes(controlType)
-    ? controlType
-    : 'input'
-  const type = Tag === 'input' ? controlType : undefined
+const FormControl = forwardRef(
+  ({ type: controlType, children, className, focus, ...htmlProps }, ref) => {
+    const Tag = ['select', 'textarea'].includes(controlType)
+      ? controlType
+      : 'input'
+    const type = Tag === 'input' ? controlType : undefined
 
-  return (
-    <Tag
-      ref={ref}
-      type={type}
-      className={classNames
-        .use(styles.control, focus && styles.focus)
-        .join(className)}
-      {...htmlProps}
-    >
-      {children}
-    </Tag>
-  )
-}
+    return (
+      <Tag
+        ref={ref}
+        type={type}
+        className={classNames
+          .use(styles.control, focus && styles.focus)
+          .join(className)}
+        {...htmlProps}
+      >
+        {children}
+      </Tag>
+    )
+  }
+)
 
-export default forwardRef(FormControl)
+export default FormControl

--- a/src/elements/forms/form.jsx
+++ b/src/elements/forms/form.jsx
@@ -1,9 +1,9 @@
 import React, { forwardRef } from 'react'
 
-const Form = ({ children, ...restProps }, ref) => (
+const Form = forwardRef(({ children, ...restProps }, ref) => (
   <form ref={ref} {...restProps}>
     {children}
   </form>
-)
+))
 
-export default forwardRef(Form)
+export default Form

--- a/src/elements/forms/group.jsx
+++ b/src/elements/forms/group.jsx
@@ -4,17 +4,16 @@ import styles from './styles.css'
 
 import { classNames } from 'utils'
 
-const FormGroup = (
-  { children, className, tag: Tag = 'p', ...htmlProps },
-  ref
-) => (
-  <Tag
-    ref={ref}
-    className={classNames.use(styles.group).join(className)}
-    {...htmlProps}
-  >
-    {children}
-  </Tag>
+const FormGroup = forwardRef(
+  ({ children, className, tag: Tag = 'p', ...htmlProps }, ref) => (
+    <Tag
+      ref={ref}
+      className={classNames.use(styles.group).join(className)}
+      {...htmlProps}
+    >
+      {children}
+    </Tag>
+  )
 )
 
-export default forwardRef(FormGroup)
+export default FormGroup

--- a/src/elements/forms/label.jsx
+++ b/src/elements/forms/label.jsx
@@ -4,15 +4,17 @@ import styles from './styles.css'
 
 import { classNames } from 'utils'
 
-const FormLabel = ({ children, className, htmlFor, ...htmlProps }, ref) => (
-  <label
-    ref={ref}
-    className={classNames.use(styles.label).join(className)}
-    htmlFor={htmlFor}
-    {...htmlProps}
-  >
-    {children}
-  </label>
+const FormLabel = forwardRef(
+  ({ children, className, htmlFor, ...htmlProps }, ref) => (
+    <label
+      ref={ref}
+      className={classNames.use(styles.label).join(className)}
+      htmlFor={htmlFor}
+      {...htmlProps}
+    >
+      {children}
+    </label>
+  )
 )
 
-export default forwardRef(FormLabel)
+export default FormLabel

--- a/src/elements/progress-spinner/progress-spinner.jsx
+++ b/src/elements/progress-spinner/progress-spinner.jsx
@@ -13,29 +13,28 @@ const progressValues = (value, max, { radius = 9 } = {}) => {
   return [filled, empty].join(' ')
 }
 
-const ProgressSpinner = (
-  { children, className, value, max = 1.0, ...htmlProps },
-  ref
-) => (
-  <svg
-    ref={ref}
-    className={classNames
-      .use(styles.spinner, value == null && styles.indeterminate)
-      .join(className)}
-    viewBox="0 0 24 24"
-    xmlns="http://www.w3.org/2000/svg"
-    {...htmlProps}
-  >
-    <circle
-      strokeWidth="2"
-      strokeLinecap="butt"
-      strokeDasharray={progressValues(value, max)}
-      cx="12"
-      cy="12"
-      r="9"
-    />
-    {children}
-  </svg>
+const ProgressSpinner = forwardRef(
+  ({ children, className, value, max = 1.0, ...htmlProps }, ref) => (
+    <svg
+      ref={ref}
+      className={classNames
+        .use(styles.spinner, value == null && styles.indeterminate)
+        .join(className)}
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      {...htmlProps}
+    >
+      <circle
+        strokeWidth="2"
+        strokeLinecap="butt"
+        strokeDasharray={progressValues(value, max)}
+        cx="12"
+        cy="12"
+        r="9"
+      />
+      {children}
+    </svg>
+  )
 )
 
-export default forwardRef(ProgressSpinner)
+export default ProgressSpinner


### PR DESCRIPTION
Fixes:
Warning: forwardRef render functions do not support propTypes or defaultProps. Did you accidentally pass a React component?