### PR TITLE
Make alt for Icon optional & allow to pass element as a helper prop for TextField

### DIFF
--- a/src/elements/forms/text-field.jsx
+++ b/src/elements/forms/text-field.jsx
@@ -134,7 +134,7 @@ TextField.propTypes = {
   /**
    * Helper message to show bellow the input
    */
-  helper: PropTypes.string,
+  helper: PropTypes.node,
   /**
    * Helper variation. Affects label position and the colour.
    *

--- a/src/elements/icon/icon.jsx
+++ b/src/elements/icon/icon.jsx
@@ -19,9 +19,9 @@ const Icon = ({ src, alt, className, ...restProps }) => (
   <svg
     className={classNames.use(iconClassNames.icon).join(className)}
     role="img"
+    aria-label={alt}
     {...restProps}
   >
-    <title>{alt}</title>
     <use href={resolve(src)} />
   </svg>
 )
@@ -37,7 +37,7 @@ Icon.propTypes = {
   /**
    * Alternative text for accessibility
    */
-  alt: PropTypes.string.isRequired,
+  alt: PropTypes.string,
 }
 
 export default Icon

--- a/src/elements/icon/icon.md
+++ b/src/elements/icon/icon.md
@@ -1,8 +1,8 @@
 ## Accessible icon
 
-Provide alternative text in `alt` prop for tech assistive users accessibility.
+Provide alternative text in `alt` prop for tech assistive user's accessibility.
 
-The component will add a `<title>` to inlined SVG element,
+The component will add a `arial-label` to inlined SVG element,
 so screen readers will be able to read it.
 
 ```jsx


### PR DESCRIPTION
We are missing alt prop for addon icons in [TextFields](https://github.com/oacore/design/blob/master/src/elements/forms/text-field.jsx#L31-L39). I don't think it makes sense to put there any alt attribute because we use arria-hidden there. If you have a better solution for this problem let me know. 