### PR TITLE
Fix searchForm param

### DIFF
--- a/bin/config.js
+++ b/bin/config.js
@@ -71,7 +71,7 @@ const loadConfigs = async () => {
 
   // load all configs
   const configs = []
-  let searchFrom = process.cwd()
+  let searchFrom = __dirname
   do {
     // eslint-disable-next-line no-await-in-loop
     const result = await explorer.search(searchFrom)


### PR DESCRIPTION
process.cwd() is not sufficient because we issue build icons command manually (because of next build) and process.cwd() is main project dir not design dir