### PR TITLE
Fix select label flickering

### DIFF
--- a/src/modules/select/select.css
+++ b/src/modules/select/select.css
@@ -17,6 +17,7 @@
   z-index: var(--select-z-index);
 }
 
+.select-wrapper:focus-within,
 .select-wrapper.focused {
   --form-control-background-color: var(--select-focused-background);
 }
@@ -92,6 +93,7 @@
 }
 
 .focused .pure > label,
+.select-wrapper:focus-within .pure > label,
 .pure input:not(:placeholder-shown) ~ label {
   /* Keeping screenreader-only tweak as is (with !important-s) for a safety */
   /* stylelint-disable declaration-no-important */


### PR DESCRIPTION
When pure select is empty and and gets unfocused for small time label is shown on the border.
It's because it gets time to remove .focused class from element hence using `:focus-with` pseudo selector.
I decided to keep .focused for compatibility reasons.