### PR TITLE
Add Section and SectionHeading

### DIFF
--- a/src/content/context.js
+++ b/src/content/context.js
@@ -1,0 +1,11 @@
+import { createContext } from 'react'
+
+const defaultContext = {
+  level: 1,
+  parentId: null,
+}
+
+const SectionContext = createContext(defaultContext)
+
+export default SectionContext
+export { defaultContext }

--- a/src/content/heading.jsx
+++ b/src/content/heading.jsx
@@ -1,4 +1,5 @@
 import React, { forwardRef, useContext } from 'react'
+import PropTypes from 'prop-types'
 
 import { Heading } from '../elements'
 import Context from './context'

--- a/src/content/heading.jsx
+++ b/src/content/heading.jsx
@@ -1,0 +1,37 @@
+import React, { forwardRef, useContext } from 'react'
+
+import { Heading } from '../elements'
+import Context from './context'
+
+const SectionHeading = forwardRef(
+  ({ children, id: forceId, level: forceLevel, ...passProps }, ref) => {
+    const parentContext = useContext(Context)
+    const level = forceLevel ?? parentContext.level ?? 1
+    const id = forceId ?? parentContext.headingId
+
+    return (
+      <Heading ref={ref} id={id} level={level} {...passProps}>
+        {children}
+      </Heading>
+    )
+  }
+)
+
+SectionHeading.propTypes = {
+  /**
+   * A local level to force the current heading heading level over the one
+   * passed via the context from the parent sectioning element.
+   *
+   * If `null` or no value (`undefined`) is passed, the prop is ignored.
+   * Otherwise, it forces the current Heading to use the passed level.
+   *
+   * In contrast to the forced `level` in the Section, this one impacts
+   * only the current heading and will not have effect on nested sections.
+   *
+   * The prop is created to provide the full control over the component if
+   * the automatic system does not work. However, we recommend avoid using it.
+   */
+  level: PropTypes.oneOf([undefined, null, 1, 2, 3, 4, 5, 6]),
+}
+
+export default SectionHeading

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -1,0 +1,2 @@
+export Section from './section'
+export Heading from './heading'

--- a/src/content/section.jsx
+++ b/src/content/section.jsx
@@ -3,22 +3,24 @@ import PropTypes from 'prop-types'
 
 import Context from './context'
 
-const HEADING_SUFFIX = 'title'
-
 const Section = forwardRef(
   (
     { children, id, level: forceLevel, tag: Tag = 'section', ...restProps },
     ref
   ) => {
     const parentContext = useContext(Context)
+
     const level = forceLevel ?? parentContext.level + 1
-    const currentContext = {
-      level,
-      parentId: id,
-    }
+    const headingId = `${id}-title`
 
     const ariaProps = {
-      'aria-labelledby': `${id}-${HEADING_SUFFIX}`,
+      'aria-labelledby': headingId,
+    }
+
+    const currentContext = {
+      level,
+      id,
+      headingId,
     }
 
     return (
@@ -47,4 +49,3 @@ Section.propTypes = {
 }
 
 export default Section
-export { HEADING_SUFFIX }

--- a/src/content/section.jsx
+++ b/src/content/section.jsx
@@ -1,0 +1,50 @@
+import React, { forwardRef, useContext } from 'react'
+import PropTypes from 'prop-types'
+
+import Context from './context'
+
+const HEADING_SUFFIX = 'title'
+
+const Section = forwardRef(
+  (
+    { children, id, level: forceLevel, tag: Tag = 'section', ...restProps },
+    ref
+  ) => {
+    const parentContext = useContext(Context)
+    const level = forceLevel ?? parentContext.level + 1
+    const currentContext = {
+      level,
+      parentId: id,
+    }
+
+    const ariaProps = {
+      'aria-labelledby': `${id}-${HEADING_SUFFIX}`,
+    }
+
+    return (
+      <Tag ref={ref} {...ariaProps} {...restProps}>
+        <Context.Provider value={currentContext}>{children}</Context.Provider>
+      </Tag>
+    )
+  }
+)
+
+Section.propTypes = {
+  /**
+   * A section level to force the current section heading level over the one
+   * passed via the context.
+   *
+   * If `null` or no value (`undefined`) is passed, the prop is ignored.
+   * Otherwise, it forces descendent Heading to use the passed level.
+   *
+   * Be aware, forcing the section level impacts not only the current section
+   * heading but all descendent sections too.
+   *
+   * The prop is created to provide the full control over the component if
+   * the automatic system does not work. However, we recommend avoid using it.
+   */
+  level: PropTypes.oneOf([undefined, null, 1, 2, 3, 4, 5, 6]),
+}
+
+export default Section
+export { HEADING_SUFFIX }


### PR DESCRIPTION
I am not sure this is work in progress or can be merged. The implementation is copied from oacore/dashboard#443. 

Styles are not copied, I think these should be separated. The rationale behind is that the current implementation allows doing something like this:

```jsx
<Page id="ref">
  <Heading>REF 2021</Heading>
  <Card id="overview" tag={Section}>
    <Heading>Overview</Heading>
  </Card>
</Page>
```

when the styled implementation will disable such functionality. However, I am not sure about such compositing either.

This partially relates to #322 but I find that class discovery should be avoided as much as possible when `aria-labelledby` is very useful. 