### PR TITLE
Update colour system to be more powerful and flexible

### DIFF
--- a/src/foundation/colors.css
+++ b/src/foundation/colors.css
@@ -3,12 +3,21 @@
  *
  * Design system colour palette. Contains shades of grey and our brand
  * colours.
+ *
+ * Guidelines:
+ * 1. Colour values are defined as HSL triple. This includes both `--color`
+ *    and `--on-color` variables.
+ * 2. Emphasis values are defined as alpha channel value.
+ * 3. The usage may look like:
+ *    ```css
+ *    color: hsl(var(--on-primary) / var(--on-primary-medium-emphasis))
+ *    ```
  */
 
 :root {
   /* Fundamentals */
-  --white: #fff;
-  --black: #000;
+  --white: #fff; /* @deprecated */
+  --black: #000; /* @deprecated */
 
   /**
    * Grey shades
@@ -16,16 +25,17 @@
    * Shades of grey reflect Material Gray palette.
    * See more: https://material.io/design/color/
    */
-  --gray-50: #fafafa;
-  --gray-100: #f5f5f5;
-  --gray-200: #eee;
-  --gray-300: #e0e0e0;
-  --gray-400: #bdbdbd;
-  --gray-500: #9e9e9e;
-  --gray-600: #757575;
-  --gray-700: #616161;
-  --gray-800: #424242;
-  --gray-900: #212121;
+  --gray-50: #fafafa; /* @deprecated */
+  --gray-100: #f5f5f5; /* @deprecated */
+  --gray-200: #eee; /* @deprecated */
+  --gray-300: #e0e0e0; /* @deprecated */
+  --gray-400: #bdbdbd; /* @deprecated */
+  --gray-500: #9e9e9e; /* @deprecated */
+  --gray-600: #757575; /* @deprecated */
+  --gray-700: #616161; /* @deprecated */
+  --gray-800: #424242; /* @deprecated */
+  --gray-900: #212121; /* @deprecated */
+
 
   /**
    * Brand accents
@@ -33,24 +43,49 @@
    * Brand accents are generated with Material Color Tool.
    * Access at: https://material.io/resources/color/
    */
+  --background: 0 0 1;
+  --on-background: 0 0 0;
+
+  /* Surface */
+  --surface: 0 0 1;
+  --on-surface: 0 0 0;
+  --on-surface-high-emphasis: .87;
+  --on-surface-medium-emphasis: .6;
+  --on-surface-disabled: .38;
+  --on-surface-overlay: var(--on-surface);
 
   /* Primary brand colour */
+  /* @deprecated, should be replaced with --primary-hsl */
   --primary: #b75400;
+  /* @deprecated, should be removed */
   --primary-light: #ef8237;
+  /* @deprecated, should be replaced with --primary-variant */
   --primary-dark: #812700;
+
+  --primary-hsl: .08 1 .36;
+  --primary-variant: .05 1 .25;
+  --on-primary: 0 0 1;
+  --on-primary-high-emphasis: 1;
+  --on-primary-medium-emphasis: .74;
+  --on-primary-disabled: .38;
+  --on-primary-overlay: 0 0 1;
 
   /* Success */
   --success: #8bc34a;
-  --success-light: #bef67a;
-  --success-dark: #5a9216;
+  --success-light: #bef67a; /* @deprecated */
+  --success-dark: #5a9216; /* @deprecated */
 
   /* Warning */
-  --warning: #fdd835;
-  --warning-light: #ffff6b;
-  --warning-dark: #c6a700;
+  --warning: #fdd835; /* @deprecated */
+  --warning-light: #ffff6b; /* @deprecated */
+  --warning-dark: #c6a700; /* @deprecated */
+
+  /* Danger */
+  --danger: #c62828; /* @deprecated */
+  --danger-light: #ff5f52; /* @deprecated */
+  --danger-dark: #8e0000; /* @deprecated */
 
   /* Error */
-  --danger: #c62828;
-  --danger-light: #ff5f52;
-  --danger-dark: #8e0000;
+  --error: .97 1 .35;
+  --on-error: 0 0 1;
 }

--- a/src/foundation/colors.css
+++ b/src/foundation/colors.css
@@ -93,7 +93,7 @@
   --on-primary-high-emphasis: 1;
   --on-primary-medium-emphasis: .74;
   --on-primary-disabled: .38;
-  --on-primary-overlay: 0 0 1;
+  --on-primary-overlay: 0deg 0% 100%;
 
   /**
    * Success

--- a/src/foundation/colors.css
+++ b/src/foundation/colors.css
@@ -12,6 +12,15 @@
  *    ```css
  *    color: hsl(var(--on-primary) / var(--on-primary-medium-emphasis))
  *    ```
+ *
+ * NOTE: For some reason, browsers don't support 0 values without a unit,
+ *       so colour values contain explicit units, i.e. 0% wherever
+ *       bare `0` would be enough. Pure integer is acceptable as a first
+ *       argument but 'deg' unit is used for the consistency.
+ *
+ * NOTE: Emphasis values are defined as a rational number between 0 and 1
+ *       instead the percentage to preserve the compatibility with the `opacity`
+ *       property.
  */
 
 :root {
@@ -48,16 +57,16 @@
    *
    * Applies to <body> only.
    */
-  --background: 0 0 1;
-  --on-background: 0 0 0;
+  --background: 0deg 0% 100%;
+  --on-background: 0deg 0% 0%;
 
   /**
    * Surface
    *
    * Apply to all surfaces: cards, lists, dialogues etc.
    */
-  --surface: 0 0 1;
-  --on-surface: 0 0 0;
+  --surface: 0deg 0% 100%;
+  --on-surface: 0deg 0% 0%;
   --on-surface-high-emphasis: .87;
   --on-surface-medium-emphasis: .6;
   --on-surface-disabled: .38;
@@ -78,9 +87,9 @@
    * Brand accents were generated with Material Color Tool.
    * Access at: https://material.io/resources/color/
    */
-  --primary-hsl: .08 1 .36;
-  --primary-variant: .05 1 .25;
-  --on-primary: 0 0 1;
+  --primary-hsl: .08deg 100% 36%;
+  --primary-variant: .05deg 100% 25%;
+  --on-primary: 0deg 0% 100%;
   --on-primary-high-emphasis: 1;
   --on-primary-medium-emphasis: .74;
   --on-primary-disabled: .38;
@@ -116,6 +125,6 @@
   /**
    * Error
    */
-  --error: .97 1 .35;
-  --on-error: 0 0 1;
+  --error: .97deg 100% 35%;
+  --on-error: 0deg 0% 100%;
 }

--- a/src/foundation/colors.css
+++ b/src/foundation/colors.css
@@ -15,38 +15,47 @@
  */
 
 :root {
-  /* Fundamentals */
-  --white: #fff; /* @deprecated */
-  --black: #000; /* @deprecated */
+  /**
+   * Fundamentals
+   *
+   * @deprecated, should be replaced with --background, --surface
+   *              and corresponding --on-* colours
+   */
+  --white: #fff;
+  --black: #000;
 
   /**
    * Grey shades
    *
    * Shades of grey reflect Material Gray palette.
    * See more: https://material.io/design/color/
+   *
+   * @deprecated, should be replaced with --on-* colour accents
    */
-  --gray-50: #fafafa; /* @deprecated */
-  --gray-100: #f5f5f5; /* @deprecated */
-  --gray-200: #eee; /* @deprecated */
-  --gray-300: #e0e0e0; /* @deprecated */
-  --gray-400: #bdbdbd; /* @deprecated */
-  --gray-500: #9e9e9e; /* @deprecated */
-  --gray-600: #757575; /* @deprecated */
-  --gray-700: #616161; /* @deprecated */
-  --gray-800: #424242; /* @deprecated */
-  --gray-900: #212121; /* @deprecated */
-
+  --gray-50: #fafafa;
+  --gray-100: #f5f5f5;
+  --gray-200: #eee;
+  --gray-300: #e0e0e0;
+  --gray-400: #bdbdbd;
+  --gray-500: #9e9e9e;
+  --gray-600: #757575;
+  --gray-700: #616161;
+  --gray-800: #424242;
+  --gray-900: #212121;
 
   /**
-   * Brand accents
+   * Environment background
    *
-   * Brand accents are generated with Material Color Tool.
-   * Access at: https://material.io/resources/color/
+   * Applies to <body> only.
    */
   --background: 0 0 1;
   --on-background: 0 0 0;
 
-  /* Surface */
+  /**
+   * Surface
+   *
+   * Apply to all surfaces: cards, lists, dialogues etc.
+   */
   --surface: 0 0 1;
   --on-surface: 0 0 0;
   --on-surface-high-emphasis: .87;
@@ -54,14 +63,21 @@
   --on-surface-disabled: .38;
   --on-surface-overlay: var(--on-surface);
 
-  /* Primary brand colour */
-  /* @deprecated, should be replaced with --primary-hsl */
+  /**
+   * Primary brand accents
+   *
+   * @deprecated, should be replaced with the new --primary accents, see below.
+   */
   --primary: #b75400;
-  /* @deprecated, should be removed */
   --primary-light: #ef8237;
-  /* @deprecated, should be replaced with --primary-variant */
   --primary-dark: #812700;
 
+  /**
+   * New primary brand accents
+   *
+   * Brand accents were generated with Material Color Tool.
+   * Access at: https://material.io/resources/color/
+   */
   --primary-hsl: .08 1 .36;
   --primary-variant: .05 1 .25;
   --on-primary: 0 0 1;
@@ -70,22 +86,36 @@
   --on-primary-disabled: .38;
   --on-primary-overlay: 0 0 1;
 
-  /* Success */
+  /**
+   * Success
+   *
+   * @deprecated, no replacement
+   */
   --success: #8bc34a;
   --success-light: #bef67a; /* @deprecated */
   --success-dark: #5a9216; /* @deprecated */
 
-  /* Warning */
+  /**
+   * Warning
+   *
+   * @deprecated, no replacement
+   */
   --warning: #fdd835; /* @deprecated */
   --warning-light: #ffff6b; /* @deprecated */
   --warning-dark: #c6a700; /* @deprecated */
 
-  /* Danger */
+  /**
+   * Danger
+   *
+   * @deprecated, should be replaced with Error, see below
+   */
   --danger: #c62828; /* @deprecated */
   --danger-light: #ff5f52; /* @deprecated */
   --danger-dark: #8e0000; /* @deprecated */
 
-  /* Error */
+  /**
+   * Error
+   */
   --error: .97 1 .35;
   --on-error: 0 0 1;
 }


### PR DESCRIPTION
1. Introduces a new more powerful and flexible technique of using colours and CSS custom properties. The system requires a lot of changes in the project, the slow adaptation approach is taken to replace the --primary colour.
2. Defines the new colour variables that are inspired by the [Material Baseline Design Kit](https://www.figma.com/community/file/778763161265841481/Material-Baseline-Design-Kit) developed by the Material Design group and provided via Figma Community.
3. Deprecates the current colour system in favour of the new more simple one.

This comes from stale #345. Merging can be either proceed or postponed to the time I test the system.