### PR TITLE
Remove gap from calculation

### DIFF
--- a/src/modules/header/styles.css
+++ b/src/modules/header/styles.css
@@ -354,7 +354,7 @@
     position: relative;
     max-width:
       calc(
-        (100vw - var(--main-content-aside-gap) - 2 * var(--page-padding-x))
+        (100vw - 2 * var(--page-padding-x))
         * var(--main-content-ratio)
       );
   }
@@ -377,7 +377,7 @@
   .select {
     max-width:
       calc(
-        (100vw - var(--main-content-aside-gap) - 2 * var(--page-padding-x))
+        (100vw - 2 * var(--page-padding-x))
         * var(--main-content-ratio) - var(--logo-min-width)
         + var(--page-padding-x)
       );


### PR DESCRIPTION
It was a mistake and it shouldn't be there. It was just a coincidence that the layout matched initially. Firstly the gap was 1rem which is almost similar to the width of the scrollbar

https://github.com/oacore/search/blob/layout-align/modules/search-layout/styles.module.css#L5-L15
